### PR TITLE
made failure on verify optional; but defaulting to true

### DIFF
--- a/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/CreateOrUpdateS3RepoMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/CreateOrUpdateS3RepoMojo.java
@@ -67,6 +67,10 @@ public class CreateOrUpdateS3RepoMojo extends AbstractMojo {
     @Parameter(property = "s3repo.autoIncrementSnapshotArtifacts", defaultValue = "true")
     private boolean autoIncrementSnapshotArtifacts;
 
+    /** Fail create/update if updated repo verification fails. */
+    @Parameter(property = "s3repo.failOnVerify", defaultValue = "true")
+    private boolean failOnVerify;
+
     @Parameter(required = true)
     private List<ArtifactItem> artifactItems;
 
@@ -228,7 +232,11 @@ public class CreateOrUpdateS3RepoMojo extends AbstractMojo {
         final int expectedPackages = originalRepoStatistics.getNumPackages() + artifactItems.size();
         // sanity check to ensure that the createrepo command worked
         if (packages != expectedPackages) {
-            throw new MojoExecutionException("Updated repo metadata has " + packages + " packages, expected " + expectedPackages);
+            final String msg = "Updated repo metadata has " + packages + " packages, expected " + expectedPackages;
+            getLog().warn(msg);
+            if (failOnVerify) {
+                throw new MojoExecutionException(msg);
+            }
         }
     }
 

--- a/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/CreateOrUpdateS3RepoMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/CreateOrUpdateS3RepoMojo.java
@@ -68,8 +68,8 @@ public class CreateOrUpdateS3RepoMojo extends AbstractMojo {
     private boolean autoIncrementSnapshotArtifacts;
 
     /** Fail create/update if updated repo verification fails. */
-    @Parameter(property = "s3repo.failOnVerify", defaultValue = "true")
-    private boolean failOnVerify;
+    @Parameter(property = "s3repo.ignoreVerificationFailures", defaultValue = "false")
+    private boolean ignoreVerificationFailures;
 
     @Parameter(required = true)
     private List<ArtifactItem> artifactItems;
@@ -234,7 +234,7 @@ public class CreateOrUpdateS3RepoMojo extends AbstractMojo {
         if (packages != expectedPackages) {
             final String msg = "Updated repo metadata has " + packages + " packages, expected " + expectedPackages;
             getLog().warn(msg);
-            if (failOnVerify) {
+            if (ignoreVerificationFailures) {
                 throw new MojoExecutionException(msg);
             }
         }

--- a/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/CreateOrUpdateS3RepoMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/CreateOrUpdateS3RepoMojo.java
@@ -234,7 +234,7 @@ public class CreateOrUpdateS3RepoMojo extends AbstractMojo {
         if (packages != expectedPackages) {
             final String msg = "Updated repo metadata has " + packages + " packages, expected " + expectedPackages;
             getLog().warn(msg);
-            if (ignoreVerificationFailures) {
+            if (!ignoreVerificationFailures) {
                 throw new MojoExecutionException(msg);
             }
         }


### PR DESCRIPTION
Am having trouble w/ verification of SNAPSHOT rpms. This PR makes failure optional; however a WARN will always be emitted on verification failures.