### PR TITLE
Fix aws temporary credentials access

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ explanation:
                     <s3AccessKey>${yourS3AccessKey}</s3AccessKey>
                     <s3SecretKey>${yourS3SecretKey}</s3SecretKey>
                     <!--
+                        Optional. Enable this flag to pass AWS STS Authentication Credentials.
+                        AWS STS Temporary Authentication has AccessKey, SecretKey and SecurityToken
+                        Use "-Ds3repo.awsStsFlag=true" on the command-line instead
+                    -->
+                    <awsStsFlag>false<awsStsFlag>
+                    <!--
+                        Optional. Pass the SecurityToken, if awsStsFlag is enabled to true.
+                        Use "-Ds3repo.s3SessionToken=YOURTEMPORARYSESSIONTOKEN" on the command-line instead
+                    -->
+                    <s3SessionToken>${yourtemporarySessionToken}</s3SessionToken>
+                    <!--
                         You can specify multiple artifact items to copy to the repo.
                     -->
                     <artifactItems>
@@ -197,6 +208,8 @@ You can use "s3repo.excludes" to specify a comma-delimted list of repo-relative 
 listed paths will be removed/deleted from the target S3 bucket. A common idiom is to use the "list-repo" goal (see below)
 to produce a comma-delimited list of ALL artifacts and then edit that list to desired exclusions to use in the rebuild-repo
 execution.
+
+You can use "s3repo.awsStsFlag=true" and specify a Temporary Session Token as "s3repo.sessionToken=YOURTOKEN" to force the plugin to use accesskey, SecretKey and SessionToken for Authentication.
 
 Use "removeOldRepodata" to cleanup old repodata which accumulates over time.
 

--- a/src/main/java/com/bazaarvoice/maven/plugin/s3repo/list/ListS3RepoMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/s3repo/list/ListS3RepoMojo.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.maven.plugin.s3repo.list;
 
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
@@ -53,6 +54,12 @@ public final class ListS3RepoMojo extends AbstractMojo {
 
     @Parameter(property = "s3repo.secretKey")
     private String s3SecretKey;
+
+    @Parameter(property = "s3repo.sessionToken")
+    private String s3SessionToken;
+
+    @Parameter(property = "s3repo.awsStsFlag", defaultValue = "false")
+    private boolean awsStsFlag;
 
     /** The createrepo executable. */
     @Parameter(property = "s3repo.createrepo", defaultValue = "createrepo")
@@ -209,11 +216,29 @@ public final class ListS3RepoMojo extends AbstractMojo {
         return summary.getKey().startsWith(metadataFilePrefix);
     }
 
-    private AmazonS3Client createS3Client() {
-        if (s3AccessKey != null || s3SecretKey != null) {
-            return new AmazonS3Client(new BasicAWSCredentials(s3AccessKey, s3SecretKey));
+    private AmazonS3Client createS3Client() throws MojoExecutionException {
+        if (awsStsFlag) {
+            try {
+                if (s3AccessKey == null) {
+                    s3AccessKey = System.getenv("AWS_ACCESS_KEY_ID");
+                }
+                if (s3SecretKey == null) {
+                    s3SecretKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+                }
+                if (s3SessionToken == null) {
+                    s3SessionToken = System.getenv("AWS_SESSION_TOKEN");
+                }
+            } catch (NullPointerException e) {
+                throw new MojoExecutionException("Failed to get the environment variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN", e);
+            }
+            BasicSessionCredentials basicSessionCredentials = new BasicSessionCredentials(s3AccessKey, s3SecretKey, s3SessionToken);
+            return new AmazonS3Client(basicSessionCredentials);
         } else {
-            return new AmazonS3Client(new DefaultAWSCredentialsProviderChain());
+            if (s3AccessKey != null || s3SecretKey != null) {
+                return new AmazonS3Client(new BasicAWSCredentials(s3AccessKey, s3SecretKey));
+            } else {
+                return new AmazonS3Client(new DefaultAWSCredentialsProviderChain());
+            }
         }
     }
 


### PR DESCRIPTION
Enabled the plugin to use AWS STS Credentials for authentication using AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN