### PR TITLE
Cross account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ s3repo-maven-plugin
 This Maven plugin supports releasing and deploying to YUM repositories hosted in S3. Additional goals allow you to
 rebuild, relocate, and list S3-based YUM repositories.
 
-The latest version is **3.5**.
+The latest version is **3.6**.
 
 Note that using S3 as a YUM repository is possible via the YUM plugin
 [yum-s3-plugin](https://github.com/jbraeuer/yum-s3-plugin).

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.bazaarvoice.commons</groupId>
         <artifactId>bv-opensource-super-pom</artifactId>
-        <version>1.3</version>
+        <version>1.4</version>
     </parent>
 
     <groupId>com.bazaarvoice.maven.plugins</groupId>
@@ -20,29 +20,33 @@
         <url>https://github.com/bazaarvoice/s3repo-maven-plugin</url>
         <connection>scm:git:git@github.com:bazaarvoice/s3repo-maven-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:bazaarvoice/s3repo-maven-plugin.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
-        <mavenVersion>3.2.3</mavenVersion>
-        <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
+        <mavenVersion>3.3.9</mavenVersion>
+        <mavenPluginPluginVersion>3.4</mavenPluginPluginVersion>
     </properties>
+
+    <prerequisites>
+      <maven>${mavenVersion}</maven>
+    </prerequisites>
 
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.9.1</version>
+            <version>1.10.69</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>15.0</version>
+            <version>19.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -52,7 +56,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.9</version>
+            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -67,12 +71,13 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.1</version>
+            <version>${mavenPluginPluginVersion}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.5.2</version>
+            <version>6.9.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -105,7 +110,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.5</version>
+                <version>1.6.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>

--- a/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/ArtifactItem.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/ArtifactItem.java
@@ -1,6 +1,6 @@
 package com.bazaarvoice.maven.plugin.s3repo.create;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.util.StringUtils;
@@ -120,7 +120,7 @@ public final class ArtifactItem {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).
+        return MoreObjects.toStringHelper(this).
                 add("groupId", groupId).
                 add("artifactId", artifactId).
                 add("version", version).

--- a/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/CreateOrUpdateS3RepoMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/s3repo/create/CreateOrUpdateS3RepoMojo.java
@@ -4,6 +4,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -48,7 +49,7 @@ import java.util.Set;
 @Mojo(name = "create-update", defaultPhase = LifecyclePhase.DEPLOY)
 public class CreateOrUpdateS3RepoMojo extends AbstractMojo {
 
-    @Component
+    @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;
 
     @Component
@@ -159,7 +160,7 @@ public class CreateOrUpdateS3RepoMojo extends AbstractMojo {
             String bucketKey = localFileToTargetS3BucketKey(toUpload, targetRepository);
             getLog().info(logPrefix + "Uploading: " + toUpload.getName() + " => s3://" + targetRepository.getBucketName() + "/" + bucketKey + "...");
             if (!doNotUpload) {
-                s3Session.putObject(new PutObjectRequest(targetBucket, bucketKey, toUpload));
+                s3Session.putObject(new PutObjectRequest(targetBucket, bucketKey, toUpload).withCannedAcl(CannedAccessControlList.BucketOwnerFullControl));
             }
         }
     }

--- a/src/main/java/com/bazaarvoice/maven/plugin/s3repo/rebuild/RebuildS3RepoMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/s3repo/rebuild/RebuildS3RepoMojo.java
@@ -4,6 +4,8 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -227,7 +229,7 @@ public final class RebuildS3RepoMojo extends AbstractMojo {
             final String bucketKey = localFileToTargetS3BucketKey(toUpload, context);
             getLog().info(logPrefix + "Uploading: " + toUpload.getName() + " => s3://" + targetRepository.getBucketName() + "/" + bucketKey + "...");
             if (!doNotUpload) {
-                s3Session.putObject(new PutObjectRequest(targetBucket, bucketKey, toUpload));
+                s3Session.putObject(new PutObjectRequest(targetBucket, bucketKey, toUpload).withCannedAcl(CannedAccessControlList.BucketOwnerFullControl));
             }
         }
 
@@ -242,7 +244,7 @@ public final class RebuildS3RepoMojo extends AbstractMojo {
                     getLog().info(logPrefix + "Uploading: " + toUpload.getName()
                         + " => s3://" + targetRepository.getBucketName() + "/" + bucketKey + "...");
                     if (!doNotUpload) {
-                        s3Session.putObject(new PutObjectRequest(targetBucket, bucketKey, toUpload));
+                        s3Session.putObject(new PutObjectRequest(targetBucket, bucketKey, toUpload).withCannedAcl(CannedAccessControlList.BucketOwnerFullControl));
                     }
                 }
             }
@@ -276,7 +278,8 @@ public final class RebuildS3RepoMojo extends AbstractMojo {
                 + "s3://" + targetRepository.getBucketName() + "/" + sourceBucketKey
                 + " => s3://" + targetRepository.getBucketName() + "/" + targetBucketKey);
             if (!doNotUpload) {
-                s3Session.copyObject(targetBucket, sourceBucketKey, targetBucket, targetBucketKey);
+                s3Session.copyObject(new CopyObjectRequest(targetBucket, sourceBucketKey, targetBucket, targetBucketKey)
+                        .withCannedAccessControlList(CannedAccessControlList.BucketOwnerFullControl));
                 s3Session.deleteObject(targetBucket, sourceBucketKey);
             }
         }

--- a/src/main/java/com/bazaarvoice/maven/plugin/s3repo/support/LocalYumRepoFacade.java
+++ b/src/main/java/com/bazaarvoice/maven/plugin/s3repo/support/LocalYumRepoFacade.java
@@ -79,7 +79,7 @@ public final class LocalYumRepoFacade {
                     final Checksum checksum = resolveMetadataChecksum(fileType, repoMetadata);
                     String digest;
                     if ("sha".equals(checksum.checksumType) || "sha1".equals(checksum.checksumType)) {
-                        digest = DigestUtils.shaHex(fileIn);
+                        digest = DigestUtils.sha1Hex(fileIn);
                     } else if ("sha256".equals(checksum.checksumType)) {
                         digest = DigestUtils.sha256Hex(fileIn);
                     } else if ("sha384".equals(checksum.checksumType)) {
@@ -146,7 +146,7 @@ public final class LocalYumRepoFacade {
             log.info("Successfully verified repo metadata for update");
 
             // if metadata already exists, we will execute "createrepo --update --skip-stat ."
-            args.add("--update", "--skip-stat");
+            args.add("--update", "--skip-stat", "--simple-md-filenames");
         }
         for (String arg : args.build()) {
             commandline.createArg().setValue(arg);


### PR DESCRIPTION
* Update dependency versions
* Set bucket-owner-full-control canned ACL when writing to S3 (works better for cross account buckets)
* Add the `--simple-md-filenames` createrepo argument. This prevents old metadata files from perpetually accumulating.